### PR TITLE
Make Timely more selfhosting-friendly

### DIFF
--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -5,7 +5,7 @@ const { Routes } = require('discord-api-types/v9');
 require("dotenv").config();
 
 const commands = [
-	new SlashCommandBuilder().setName("timely").setDescription("Configure Timely bot for your time zone and your country's daylight savings time.")
+	new SlashCommandBuilder().setName(process.env.BOT_NAME.toLowerCase()).setDescription(`Configure ${process.env.BOT_NAME} bot for your time zone and your country's daylight savings time.`)
 ].map(command => command.toJSON());
 
 module.exports.registerCommands = async () => {

--- a/deploy-commands.js
+++ b/deploy-commands.js
@@ -8,7 +8,7 @@ const commands = [
 	new SlashCommandBuilder().setName("timely").setDescription("Configure Timely bot for your time zone and your country's daylight savings time.")
 ].map(command => command.toJSON());
 
-const registerCommands = async () => {
+module.exports.registerCommands = async () => {
 	const rest = new REST({ version: '9' }).setToken(process.env.BOT_TOKEN);
 
 	await rest.put(
@@ -16,7 +16,5 @@ const registerCommands = async () => {
 		{ body: commands },
 	);
 
-	console.log("Finished!");
+	console.log("Registered slash commands!");
 }
-
-registerCommands();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.7"
+
+services: 
+  bot:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    env_file:
+      - .env  
+    restart: always 

--- a/dockerfile
+++ b/dockerfile
@@ -4,11 +4,11 @@ FROM node:latest
 RUN mkdir -p /usr/src/bot
 WORKDIR /usr/src/bot
 
-# install dependencies
+# Install dependencies
 COPY package.json /usr/src/bot
 RUN npm install
 
-# copy rest of the files
+# Copy rest of the files
 COPY . /usr/src/bot
 
 # Start the bot

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,15 @@
+FROM node:latest
+
+# Create the directory
+RUN mkdir -p /usr/src/bot
+WORKDIR /usr/src/bot
+
+# install dependencies
+COPY package.json /usr/src/bot
+RUN npm install
+
+# copy rest of the files
+COPY . /usr/src/bot
+
+# Start the bot
+CMD ["node", "index.js"]

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ require("dotenv").config();
 const timezonePrefix = "timelyTZ";
 const dstPrefix = "timelyDST";
 
-const setupMessage = "Please configure your time zone and daylight savings settings with the dropdowns below.  Your settings will be used across all servers that use Timely, so you will only ever have to do this once!";
+const setupMessage = `Please configure your time zone and daylight savings settings with the dropdowns below.  Your settings will be used across all servers that use ${process.env.BOT_NAME}, so you will only ever have to do this once!`;
 
 let database = null;
 
@@ -44,7 +44,7 @@ client.once('ready', () => {
 client.on("interactionCreate", async interaction => {
 	if (!interaction.isCommand()) return;
 
-	if (interaction.commandName === "timely") {
+	if (interaction.commandName === process.env.BOT_NAME.toLowerCase()) {
 		let rows = [];
 
 		const userTZ = (await getUserInfo(interaction.user.id) || {});
@@ -83,14 +83,14 @@ client.on("interactionCreate", async interaction => {
 	if (!interaction.isSelectMenu()) return;
 
 	try {
-		if (((interaction.message.interaction.commandName === "timely") || (interaction.message.interaction.name === "timely")) && (interaction.values[0])) {
+		if (((interaction.message.interaction.commandName === process.env.BOT_NAME.toLowerCase()) || (interaction.message.interaction.name === process.env.BOT_NAME.toLowerCase())) && (interaction.values[0])) {
 			let interactionData = interaction.values[0].split(":");
 
 			switch (interactionData[0]) {
 				case timezonePrefix:
 					let tzValue = interactionData[1];
 					await database.ref("users/" + interaction.user.id + "/timezone").set(tzValue);
-					await interaction.reply({ content: "Timezone set to `" + timezones.find(tz => tz.value === tzValue).label + "`\n\nTimely will now reply to any of your posts containing times and convert them into Discord timestamps.", ephemeral: true })
+					await interaction.reply({ content: "Timezone set to `" + timezones.find(tz => tz.value === tzValue).label + `\`\`\n\n${process.env.BOT_NAME} will now reply to any of your posts containing times and convert them into Discord timestamps.`, ephemeral: true })
 					break;
 				case dstPrefix:
 					let dsValue = interactionData[1];

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ require("dotenv").config();
 const timezonePrefix = "timelyTZ";
 const dstPrefix = "timelyDST";
 
-const setupMessage = "Please configure your time zone and daylight savings settings with the dropdowns below.  Your settings will be used across all servers that use" + process.env.BOT_NAME + ", so you will only ever have to do this once!";
+const setupMessage = "Please configure your time zone and daylight savings settings with the dropdowns below.  Your settings will be used across all servers that use " + process.env.BOT_NAME + ", so you will only ever have to do this once!";
 
 let database = null;
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const firebaseAdmin = require("firebase-admin");
 const { Client, Intents, MessageActionRow, MessageSelectMenu, MessageEmbed } = require("discord.js");
+const deployCommands = require("./deploy-commands.js");
 const timezones = require("./timezones.json");
 const DST = require("./DST.json");
 const tzOverrides = require("./timezoneOverrides.json");
@@ -275,5 +276,6 @@ const setStatus = () => {
 
 // Log the bot into Discord.
 client.login(process.env.BOT_TOKEN).then(() => {
+	deployCommands.registerCommands();
 	setInterval(setStatus, 3600000);  // Update status once per hour.
 });

--- a/index.js
+++ b/index.js
@@ -27,9 +27,9 @@ client.once('ready', () => {
 			auth_uri: "https://accounts.google.com/o/oauth2/auth",
 			token_uri: "https://oauth2.googleapis.com/token",
 			auth_provider_x509_cert_url: "https://www.googleapis.com/oauth2/v1/certs",
-			client_x509_cert_url: "https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk-pln7w%40timekeeper-bot.iam.gserviceaccount.com"
+			client_x509_cert_url: process.env.SA_CLIENT_CERT_URL
 		}),
-		databaseURL:"https://timekeeper-bot-default-rtdb.firebaseio.com" 
+		databaseURL: process.env.SA_DATABASE_URL
 	});
 
 	database = firebaseAdmin.database();

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ require("dotenv").config();
 const timezonePrefix = "timelyTZ";
 const dstPrefix = "timelyDST";
 
-const setupMessage = `Please configure your time zone and daylight savings settings with the dropdowns below.  Your settings will be used across all servers that use ${process.env.BOT_NAME}, so you will only ever have to do this once!`;
+const setupMessage = "Please configure your time zone and daylight savings settings with the dropdowns below.  Your settings will be used across all servers that use" + process.env.BOT_NAME + ", so you will only ever have to do this once!";
 
 let database = null;
 
@@ -90,7 +90,7 @@ client.on("interactionCreate", async interaction => {
 				case timezonePrefix:
 					let tzValue = interactionData[1];
 					await database.ref("users/" + interaction.user.id + "/timezone").set(tzValue);
-					await interaction.reply({ content: "Timezone set to `" + timezones.find(tz => tz.value === tzValue).label + `\`\`\n\n${process.env.BOT_NAME} will now reply to any of your posts containing times and convert them into Discord timestamps.`, ephemeral: true })
+					await interaction.reply({ content: "Timezone set to `" + timezones.find(tz => tz.value === tzValue).label + "`\n\n" + process.env.BOT_NAME + "will now reply to any of your posts containing times and convert them into Discord timestamps.", ephemeral: true })
 					break;
 				case dstPrefix:
 					let dsValue = interactionData[1];

--- a/timezoneOverrides.json
+++ b/timezoneOverrides.json
@@ -96,7 +96,7 @@
 		"dst": "Cuba"
 	},
 	{
-		"keys": [ "edt", "est", "eastern", "us eastern", "new york", "toronto" ],
+		"keys": [ "edt", "est", "et", "eastern", "us eastern", "new york", "toronto" ],
 		"timezone": "R",
 		"dst": "US & Canada"
 	},

--- a/timezoneOverrides.json
+++ b/timezoneOverrides.json
@@ -46,7 +46,7 @@
 		"dst": "Mexico"
 	},
 	{
-		"keys": [ "pdt", "pst", "pacific", "us pacific", "los angeles", "vancouver" ],
+		"keys": [ "pdt", "pst", "pt", "pacific", "us pacific", "los angeles", "vancouver"],
 		"timezone": "U",
 		"dst": "US & Canada"
 	},
@@ -81,7 +81,7 @@
 		"dst": "Mexico"
 	},
 	{
-		"keys": [ "cdt", "cst", "central", "us central", "chicago", "winnipeg" ],
+		"keys": [ "cdt", "cst", "ct", "central", "us central", "chicago", "winnipeg" ],
 		"timezone": "S",
 		"dst": "US & Canada"
 	},


### PR DESCRIPTION
This PR implements several features:
- Add Dockerfile and docker-compose.yml to make hosting simpler
- Add SA_CLIENT_CERT_URL and SA_DATABASE_URL to .env variables to allow different Firebase databases
- Add BOT_NAME .env variable to customize the name used in commands, etc
- Register Slash Commands when the bot is launched
- Add a couple American time zones keys that appeared to be missing

I would love feedback on this, if you have any :)