### PR TITLE
handling for 24hr time, date still agnostic

### DIFF
--- a/index.js
+++ b/index.js
@@ -234,12 +234,12 @@ const convertTime = (time, tzInfo) => {
 		let inputHours = time.match(/^\d+/);
 		let curHours = tmpDate.getUTCHours() + offset;
 
-		if (inputHours) {
-			if ((curHours % 12) > inputHours[0]) {
-				ampm = (curHours >= 12) ? "am" : "pm";
-			} else {
-				ampm = (curHours >= 12) ? "pm" : "am";
-			}
+		// Handle 24hr time
+		if (inputHours >= 12) {
+			ampm = "pm"
+			time = time.replace(/^\d+/, inputHours % 12)
+		} else {
+			ampm = "am"
 		}
 	}
 


### PR DESCRIPTION
Returns correct time in am/pm when given time in 24hr format eg. 23:00 or 18:00. Tested on BST, MDT, CDT, PDT, JST, AEST.  Date still refers to the past for some conversions.